### PR TITLE
Use `inode/x-empty` as default MIME type

### DIFF
--- a/Civi/ExternalFile/Api4/Action/ExternalFile/CreateAction.php
+++ b/Civi/ExternalFile/Api4/Action/ExternalFile/CreateAction.php
@@ -87,6 +87,7 @@ final class CreateAction extends DAOCreateAction {
     $this->values['download_start_date'] ??= NULL;
     $this->values['custom_data'] ??= NULL;
     $this->values['last_modified'] ??= NULL;
+    $this->values['file_mime_type'] ??= 'inode/x-empty';
 
     $result = new Result();
     parent::_run($result);

--- a/Civi/ExternalFile/AttachmentManager.php
+++ b/Civi/ExternalFile/AttachmentManager.php
@@ -67,7 +67,7 @@ final class AttachmentManager implements AttachmentManagerInterface {
       // content is required by Attachment entity.
       'content' => '',
       // mime_type is required by Attachment entity.
-      'mime_type' => $mimeType ?? 'application/octet-stream',
+      'mime_type' => $mimeType ?? 'inode/x-empty',
       'description' => $description,
       'created_id' => $createdId,
       'sequential' => 1,

--- a/tests/phpunit/Civi/Api4/ExternalFileTest.php
+++ b/tests/phpunit/Civi/Api4/ExternalFileTest.php
@@ -70,7 +70,7 @@ final class ExternalFileTest extends AbstractExternalFileHeadlessTestCase {
       'identifier' => $createValues['identifier'],
       'custom_data' => NULL,
       'last_modified' => NULL,
-      'file_mime_type' => 'application/octet-stream',
+      'file_mime_type' => 'inode/x-empty',
       'file_description' => NULL,
       'file_upload_date' => $createValues['file_upload_date'],
       'file_created_id' => NULL,


### PR DESCRIPTION
A MIME type is [required since CiviCRM 6.2](https://github.com/civicrm/civicrm-core/commit/f2fd29c393d5c9ad2cf275f31fec0f5109fed659#diff-136c336cc00909ca6a830273732d27ee232a4b0b07e18f080e699c268fce21c7).

systopia-reference: 29409